### PR TITLE
[Debug] Consistent scroll zoom behavior when detected with direction or deltas

### DIFF
--- a/src/germinal/germinal-terminal.c
+++ b/src/germinal/germinal-terminal.c
@@ -195,7 +195,7 @@ on_scroll (GtkWidget      *widget,
         }
         else if (gdk_event_get_scroll_deltas ((GdkEvent*) event, NULL, &y))
         {
-            if (y > 0)
+            if (y < 0)
             {
                 germinal_terminal_zoom (self);
                 return GDK_EVENT_STOP;


### PR DESCRIPTION
In Germinal 21, when `gdk_event_get_scroll_direction` fails but `gdk_event_get_scroll_deltas` does not (which happens now on my laptop, and might be a consequence of your refactoring over last week), the way the zoom-with-scroll works is inverted, _i.e._:
- `<Ctrl><Scroll up>` zooms out (font size decreases);
- `<Ctrl><Scroll down>` zooms in (text size increases).

The quite obvious solution towards consistency of the feature was to invert the condition in the incriminated test.